### PR TITLE
protect against NPE

### DIFF
--- a/src/main/java/com/ning/compress/lzf/BufferRecycler.java
+++ b/src/main/java/com/ning/compress/lzf/BufferRecycler.java
@@ -16,7 +16,7 @@ public class BufferRecycler
     private final static int MIN_OUTPUT_BUFFER = 8000;
     
     /**
-     * This <code>ThreadLocal</code> contains a {@link java.lang.ref.SoftRerefence}
+     * This <code>ThreadLocal</code> contains a {@link java.lang.ref.SoftReference}
      * to a {@link BufferRecycler} used to provide a low-cost
      * buffer recycling for buffers we need for encoding, decoding.
      */


### PR DESCRIPTION
On some very rare occasions we get an NPE in the BufferRecycler:

at com.ning.compress.lzf.BufferRecycler?.releaseInputBuffer(BufferRecycler?.java:130) at com.ning.compress.lzf.LZFInputStream.close(LZFInputStream.java:163) at 

It also occasionally occurs on line 148.  I've just added a small check to make sure the buffer is not null before calling .length on it.
