### PR TITLE
Fix JDK 1.5 compatibility issue

### DIFF
--- a/src/main/java/com/ning/compress/CompressionFormatException.java
+++ b/src/main/java/com/ning/compress/CompressionFormatException.java
@@ -17,10 +17,12 @@ public class CompressionFormatException extends IOException
     }
 
     protected CompressionFormatException(Throwable t) {
-        super(t);
+        super();
+        initCause(t);
     }
 
     protected CompressionFormatException(String message, Throwable t) {
-        super(message, t);
+        super(message);
+        initCause(t);
     }
 }


### PR DESCRIPTION
The IOException constructor that takes a cause argument wasn't
introduced until JDK 1.6 (unfortunately).
