### PR TITLE
Fix data corruption on write attempt after close

### DIFF
--- a/src/main/java/com/ning/compress/gzip/OptimizedGZIPOutputStream.java
+++ b/src/main/java/com/ning/compress/gzip/OptimizedGZIPOutputStream.java
@@ -92,6 +92,7 @@ public class OptimizedGZIPOutputStream
     public void close() throws IOException
     {
         _deflaterOut.finish();
+        _deflaterOut = null;
         _writeTrailer(_rawOut);
         _rawOut.close();
         Deflater d = _deflater;


### PR DESCRIPTION
DeflaterOutputStream internally holds a reference to the Deflater.
Writing to the stream after calling close thus silently corrupts the
Deflater. This causes data breech between two consecutive user of the
same Deflater instance. This fix would cause error in what obviously
a erroneous use of the stream instead of silent corruption.
