### PR TITLE
Overload of factory methods and constructors in Encoders and Streams, to...

### DIFF
--- a/src/main/java/com/ning/compress/gzip/GZIPUncompressor.java
+++ b/src/main/java/com/ning/compress/gzip/GZIPUncompressor.java
@@ -171,17 +171,22 @@ public class GZIPUncompressor extends Uncompressor
     
     public GZIPUncompressor(DataHandler h)
     {
-        this(h, DEFAULT_CHUNK_SIZE);
+        this(h, DEFAULT_CHUNK_SIZE, BufferRecycler.instance(), GZIPRecycler.instance());
     }
     
     public GZIPUncompressor(DataHandler h, int inputChunkLength)
     {
+        this(h, inputChunkLength, BufferRecycler.instance(), GZIPRecycler.instance());
+    }
+
+    public GZIPUncompressor(DataHandler h, int inputChunkLength, BufferRecycler bufferRecycler, GZIPRecycler gzipRecycler)
+    {
         _inputChunkLength = inputChunkLength;
         _handler = h;
-        _recycler = BufferRecycler.instance();
-        _decodeBuffer = _recycler.allocDecodeBuffer(DECODE_BUFFER_SIZE);
-        _gzipRecycler = GZIPRecycler.instance();
-        _inflater = _gzipRecycler.allocInflater();
+        _recycler = bufferRecycler;
+        _decodeBuffer = bufferRecycler.allocDecodeBuffer(DECODE_BUFFER_SIZE);
+        _gzipRecycler = gzipRecycler;
+        _inflater = gzipRecycler.allocInflater();
         _crc = new CRC32();
     }
 

--- a/src/main/java/com/ning/compress/gzip/OptimizedGZIPInputStream.java
+++ b/src/main/java/com/ning/compress/gzip/OptimizedGZIPInputStream.java
@@ -78,14 +78,19 @@ public class OptimizedGZIPInputStream
     
     public OptimizedGZIPInputStream(InputStream in) throws IOException
     {
+        this(in, BufferRecycler.instance(), GZIPRecycler.instance());
+    }
+
+    public OptimizedGZIPInputStream(InputStream in, BufferRecycler bufferRecycler, GZIPRecycler gzipRecycler) throws IOException
+    {
         super();
-        _bufferRecycler = BufferRecycler.instance();
-        _gzipRecycler = GZIPRecycler.instance();
+        _bufferRecycler = bufferRecycler;
+        _gzipRecycler = gzipRecycler;
         _rawInput = in;
-        _buffer = _bufferRecycler.allocInputBuffer(INPUT_BUFFER_SIZE);
+        _buffer = bufferRecycler.allocInputBuffer(INPUT_BUFFER_SIZE);
 
         _bufferPtr = _bufferEnd = 0;
-        _inflater = _gzipRecycler.allocInflater();
+        _inflater = gzipRecycler.allocInflater();
         _crc = new CRC32();
 
         // And then need to process header...

--- a/src/main/java/com/ning/compress/lzf/LZFInputStream.java
+++ b/src/main/java/com/ning/compress/lzf/LZFInputStream.java
@@ -83,7 +83,7 @@ public class LZFInputStream extends InputStream
     public LZFInputStream(final ChunkDecoder decoder, final InputStream in)
         throws IOException
     {
-        this(decoder, in, false);
+        this(decoder, in, BufferRecycler.instance(), false);
     }
     
     /**
@@ -94,21 +94,45 @@ public class LZFInputStream extends InputStream
      */
     public LZFInputStream(final InputStream in, boolean fullReads) throws IOException
     {
-        this(ChunkDecoderFactory.optimalInstance(), in, fullReads);
+        this(ChunkDecoderFactory.optimalInstance(), in, BufferRecycler.instance(), fullReads);
     }
 
     public LZFInputStream(final ChunkDecoder decoder, final InputStream in, boolean fullReads)
         throws IOException
     {
+        this(decoder, in, BufferRecycler.instance(), fullReads);
+    }
+
+    public LZFInputStream(final InputStream inputStream, final BufferRecycler bufferRecycler) throws IOException
+    {
+        this(inputStream, bufferRecycler, false);
+    }
+
+    /**
+     * @param in Underlying input stream to use
+     * @param fullReads Whether {@link #read(byte[])} should try to read exactly
+     *   as many bytes as requested (true); or just however many happen to be
+     *   available (false)
+	 * @param bufferRecycler Buffer recycler instance, for usages where the
+	 *   caller manages the recycler instances
+     */
+    public LZFInputStream(final InputStream in, final BufferRecycler bufferRecycler, boolean fullReads) throws IOException
+    {
+        this(ChunkDecoderFactory.optimalInstance(), in, bufferRecycler, fullReads);
+    }
+
+	public LZFInputStream(final ChunkDecoder decoder, final InputStream in, final BufferRecycler bufferRecycler, boolean fullReads)
+        throws IOException
+    {
         super();
         _decoder = decoder;
-        _recycler = BufferRecycler.instance();
+        _recycler = bufferRecycler;
         _inputStream = in;
         _inputStreamClosed = false;
         _cfgFullReads = fullReads;
 
-        _inputBuffer = _recycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
-        _decodedBytes = _recycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _inputBuffer = bufferRecycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _decodedBytes = bufferRecycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
     }
 
     /**

--- a/src/main/java/com/ning/compress/lzf/LZFOutputStream.java
+++ b/src/main/java/com/ning/compress/lzf/LZFOutputStream.java
@@ -28,7 +28,7 @@ import com.ning.compress.lzf.util.ChunkEncoderFactory;
  */
 public class LZFOutputStream extends FilterOutputStream implements WritableByteChannel
 {
-    private static final int OUTPUT_BUFFER_SIZE = LZFChunk.MAX_CHUNK_LEN;
+    private static final int DEFAULT_OUTPUT_BUFFER_SIZE = LZFChunk.MAX_CHUNK_LEN;
 
     private final ChunkEncoder _encoder;
     private final BufferRecycler _recycler;
@@ -58,15 +58,34 @@ public class LZFOutputStream extends FilterOutputStream implements WritableByteC
 
     public LZFOutputStream(final OutputStream outputStream)
     {
-        this(ChunkEncoderFactory.optimalInstance(OUTPUT_BUFFER_SIZE), outputStream);
+        this(ChunkEncoderFactory.optimalInstance(DEFAULT_OUTPUT_BUFFER_SIZE), outputStream);
     }
 
     public LZFOutputStream(final ChunkEncoder encoder, final OutputStream outputStream)
     {
+        this(encoder, outputStream, DEFAULT_OUTPUT_BUFFER_SIZE, encoder._recycler);
+    }
+
+    public LZFOutputStream(final OutputStream outputStream, final BufferRecycler bufferRecycler)
+    {
+        this(ChunkEncoderFactory.optimalInstance(bufferRecycler), outputStream, bufferRecycler);
+    }
+
+    public LZFOutputStream(final ChunkEncoder encoder, final OutputStream outputStream, final BufferRecycler bufferRecycler)
+    {
+        this(encoder, outputStream, DEFAULT_OUTPUT_BUFFER_SIZE, bufferRecycler);
+    }
+
+    public LZFOutputStream(final ChunkEncoder encoder, final OutputStream outputStream,
+			               final int bufferSize, BufferRecycler bufferRecycler)
+    {
         super(outputStream);
         _encoder = encoder;
-        _recycler = BufferRecycler.instance();
-        _outputBuffer = _recycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
+		if (bufferRecycler==null) {
+			bufferRecycler = _encoder._recycler;
+		}
+        _recycler = bufferRecycler;
+        _outputBuffer = bufferRecycler.allocOutputBuffer(bufferSize);
         _outputStreamClosed = false;
     }
 

--- a/src/main/java/com/ning/compress/lzf/LZFUncompressor.java
+++ b/src/main/java/com/ning/compress/lzf/LZFUncompressor.java
@@ -109,14 +109,23 @@ public class LZFUncompressor extends Uncompressor
      */
     
     public LZFUncompressor(DataHandler handler) {
-        this(handler, ChunkDecoderFactory.optimalInstance());
+        this(handler, ChunkDecoderFactory.optimalInstance(), BufferRecycler.instance());
+    }
+    
+    public LZFUncompressor(DataHandler handler, BufferRecycler bufferRecycler) {
+        this(handler, ChunkDecoderFactory.optimalInstance(), bufferRecycler);
     }
     
     public LZFUncompressor(DataHandler handler, ChunkDecoder dec)
     {
+        this(handler, dec, BufferRecycler.instance());
+    }
+
+    public LZFUncompressor(DataHandler handler, ChunkDecoder dec, BufferRecycler bufferRecycler)
+    {
         _handler = handler;
         _decoder = dec;
-        _recycler = BufferRecycler.instance();
+        _recycler = bufferRecycler;
     }
 
     /*

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoder.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoder.java
@@ -1,5 +1,6 @@
 package com.ning.compress.lzf.impl;
 
+import com.ning.compress.BufferRecycler;
 import java.lang.reflect.Field;
 
 import sun.misc.Unsafe;
@@ -42,6 +43,14 @@ public abstract class UnsafeChunkEncoder
 
     public UnsafeChunkEncoder(int totalLength, boolean bogus) {
         super(totalLength, bogus);
+    }
+
+    public UnsafeChunkEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        super(totalLength, bufferRecycler);
+    }
+
+    public UnsafeChunkEncoder(int totalLength, BufferRecycler bufferRecycler, boolean bogus) {
+        super(totalLength, bufferRecycler, bogus);
     }
 
     /*

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderBE.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderBE.java
@@ -1,5 +1,6 @@
 package com.ning.compress.lzf.impl;
 
+import com.ning.compress.BufferRecycler;
 import com.ning.compress.lzf.LZFChunk;
 
 /**
@@ -16,6 +17,14 @@ public final class UnsafeChunkEncoderBE
     public UnsafeChunkEncoderBE(int totalLength, boolean bogus) {
         super(totalLength, bogus);
     }
+    public UnsafeChunkEncoderBE(int totalLength, BufferRecycler bufferRecycler) {
+        super(totalLength, bufferRecycler);
+    }
+
+    public UnsafeChunkEncoderBE(int totalLength, BufferRecycler bufferRecycler, boolean bogus) {
+        super(totalLength, bufferRecycler, bogus);
+    }
+
 
     @Override
     protected int tryCompress(byte[] in, int inPos, int inEnd, byte[] out, int outPos)

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderLE.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderLE.java
@@ -1,5 +1,6 @@
 package com.ning.compress.lzf.impl;
 
+import com.ning.compress.BufferRecycler;
 import com.ning.compress.lzf.LZFChunk;
 
 /**
@@ -17,7 +18,15 @@ public class UnsafeChunkEncoderLE
         super(totalLength, bogus);
     }
 
-    @Override
+    public UnsafeChunkEncoderLE(int totalLength, BufferRecycler bufferRecycler) {
+        super(totalLength, bufferRecycler);
+    }
+
+    public UnsafeChunkEncoderLE(int totalLength, BufferRecycler bufferRecycler, boolean bogus) {
+        super(totalLength, bufferRecycler, bogus);
+    }
+
+	@Override
     protected int tryCompress(byte[] in, int inPos, int inEnd, byte[] out, int outPos)
     {
         final int[] hashTable = _hashTable;

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoders.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoders.java
@@ -11,6 +11,7 @@
 
 package com.ning.compress.lzf.impl;
 
+import com.ning.compress.BufferRecycler;
 import java.nio.ByteOrder;
 
 
@@ -38,5 +39,19 @@ public final class UnsafeChunkEncoders
             return new UnsafeChunkEncoderLE(totalLength, false);
         }
         return new UnsafeChunkEncoderBE(totalLength, false);
+    }
+
+    public static UnsafeChunkEncoder createEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        if (LITTLE_ENDIAN) {
+            return new UnsafeChunkEncoderLE(totalLength, bufferRecycler);
+        }
+        return new UnsafeChunkEncoderBE(totalLength, bufferRecycler);
+    }
+
+    public static UnsafeChunkEncoder createNonAllocatingEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        if (LITTLE_ENDIAN) {
+            return new UnsafeChunkEncoderLE(totalLength, bufferRecycler, false);
+        }
+        return new UnsafeChunkEncoderBE(totalLength, bufferRecycler, false);
     }
 }

--- a/src/main/java/com/ning/compress/lzf/impl/VanillaChunkEncoder.java
+++ b/src/main/java/com/ning/compress/lzf/impl/VanillaChunkEncoder.java
@@ -1,5 +1,6 @@
 package com.ning.compress.lzf.impl;
 
+import com.ning.compress.BufferRecycler;
 import com.ning.compress.lzf.ChunkEncoder;
 import com.ning.compress.lzf.LZFChunk;
 
@@ -22,8 +23,29 @@ public class VanillaChunkEncoder
         super(totalLength, bogus);
     }
 
+    /**
+     * @param totalLength Total encoded length; used for calculating size
+     *   of hash table to use
+	 * @param bufferRecycler The BufferRecycler instance
+     */
+    public VanillaChunkEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        super(totalLength, bufferRecycler);
+    }
+
+    /**
+     * Alternate constructor used when we want to avoid allocation encoding
+     * buffer, in cases where caller wants full control over allocations.
+     */
+    protected VanillaChunkEncoder(int totalLength, BufferRecycler bufferRecycler, boolean bogus) {
+        super(totalLength, bufferRecycler, bogus);
+    }
+
     public static VanillaChunkEncoder nonAllocatingEncoder(int totalLength) {
         return new VanillaChunkEncoder(totalLength, true);
+    }
+    
+    public static VanillaChunkEncoder nonAllocatingEncoder(int totalLength, BufferRecycler bufferRecycler) {
+        return new VanillaChunkEncoder(totalLength, bufferRecycler, true);
     }
     
     /*

--- a/src/main/java/com/ning/compress/lzf/parallel/PLZFOutputStream.java
+++ b/src/main/java/com/ning/compress/lzf/parallel/PLZFOutputStream.java
@@ -41,7 +41,7 @@ import com.ning.compress.lzf.LZFChunk;
  */
 public class PLZFOutputStream extends FilterOutputStream implements WritableByteChannel
 {
-    private static final int OUTPUT_BUFFER_SIZE = LZFChunk.MAX_CHUNK_LEN;
+    private static final int DEFAULT_OUTPUT_BUFFER_SIZE = LZFChunk.MAX_CHUNK_LEN;
 
     protected byte[] _outputBuffer;
     protected int _position = 0;
@@ -65,16 +65,20 @@ public class PLZFOutputStream extends FilterOutputStream implements WritableByte
      */
 
     public PLZFOutputStream(final OutputStream outputStream) {
-        this(outputStream, getNThreads());
+        this(outputStream, DEFAULT_OUTPUT_BUFFER_SIZE, getNThreads());
     }
 
     protected PLZFOutputStream(final OutputStream outputStream, int nThreads) {
+        this(outputStream, DEFAULT_OUTPUT_BUFFER_SIZE, nThreads);
+    }
+
+    protected PLZFOutputStream(final OutputStream outputStream, final int bufferSize, int nThreads) {
         super(outputStream);
         _outputStreamClosed = false;
         compressExecutor = new ThreadPoolExecutor(nThreads, nThreads, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>()); // unbounded
         ((ThreadPoolExecutor)compressExecutor).allowCoreThreadTimeOut(true);
         writeExecutor = Executors.newSingleThreadExecutor(); // unbounded
-        blockManager = new BlockManager(nThreads * 2, OUTPUT_BUFFER_SIZE); // this is where the bounds will be enforced!
+        blockManager = new BlockManager(nThreads * 2, bufferSize); // this is where the bounds will be enforced!
         _outputBuffer = blockManager.getBlockFromPool();
     }
 

--- a/src/main/java/com/ning/compress/lzf/util/ChunkEncoderFactory.java
+++ b/src/main/java/com/ning/compress/lzf/util/ChunkEncoderFactory.java
@@ -1,5 +1,6 @@
 package com.ning.compress.lzf.util;
 
+import com.ning.compress.BufferRecycler;
 import com.ning.compress.lzf.ChunkEncoder;
 import com.ning.compress.lzf.LZFChunk;
 import com.ning.compress.lzf.impl.UnsafeChunkEncoders;
@@ -35,6 +36,8 @@ public class ChunkEncoderFactory
      * non-standard platforms it may be necessary to either directly load
      * instances, or use {@link #safeInstance}.
      *
+	 * <p/>Uses a ThreadLocal soft-referenced BufferRecycler instance.
+	 * 
      * @param totalLength Expected total length of content to compress; only matters
      *    for content that is smaller than maximum chunk size (64k), to optimize
      *    encoding hash tables
@@ -50,6 +53,8 @@ public class ChunkEncoderFactory
     /**
      * Factory method for constructing encoder that is always passed buffer
      * externally, so that it will not (nor need) allocate encoding buffer.
+     *
+	 * <p/>Uses a ThreadLocal soft-referenced BufferRecycler instance.
      */
     public static ChunkEncoder optimalNonAllocatingInstance(int totalLength) {
         try {
@@ -68,9 +73,12 @@ public class ChunkEncoderFactory
     public static ChunkEncoder safeInstance() {
         return safeInstance(LZFChunk.MAX_CHUNK_LEN);
     }
+	
     /**
      * Method that can be used to ensure that a "safe" compressor instance is loaded.
      * Safe here means that it should work on any and all Java platforms.
+     *
+	 * <p/>Uses a ThreadLocal soft-referenced BufferRecycler instance.
      *
      * @param totalLength Expected total length of content to compress; only matters
      *    for content that is smaller than maximum chunk size (64k), to optimize
@@ -83,8 +91,82 @@ public class ChunkEncoderFactory
     /**
      * Factory method for constructing encoder that is always passed buffer
      * externally, so that it will not (nor need) allocate encoding buffer.
+     *
+	 * <p/>Uses a ThreadLocal soft-referenced BufferRecycler instance.
      */
     public static ChunkEncoder safeNonAllocatingInstance(int totalLength) {
         return VanillaChunkEncoder.nonAllocatingEncoder(totalLength);
+    }
+
+    /**
+     * Convenience method, equivalent to:
+     *<code>
+     *   return optimalInstance(LZFChunk.MAX_CHUNK_LEN, bufferRecycler);
+     *</code>
+     */
+    public static ChunkEncoder optimalInstance(BufferRecycler bufferRecycler) {
+        return optimalInstance(LZFChunk.MAX_CHUNK_LEN, bufferRecycler);
+    }
+
+    /**
+     * Method to use for getting compressor instance that uses the most optimal
+     * available methods for underlying data access. It should be safe to call
+     * this method as implementations are dynamically loaded; however, on some
+     * non-standard platforms it may be necessary to either directly load
+     * instances, or use {@link #safeInstance}.
+	 * 
+     * @param totalLength Expected total length of content to compress; only matters
+     *    for content that is smaller than maximum chunk size (64k), to optimize
+     *    encoding hash tables
+	 * @param bufferRecycler The BufferRecycler instance
+     */
+    public static ChunkEncoder optimalInstance(int totalLength, BufferRecycler bufferRecycler) {
+        try {
+            return UnsafeChunkEncoders.createEncoder(totalLength, bufferRecycler);
+        } catch (Exception e) {
+            return safeInstance(totalLength, bufferRecycler);
+        }
+    }
+
+    /**
+     * Factory method for constructing encoder that is always passed buffer
+     * externally, so that it will not (nor need) allocate encoding buffer.
+     */
+    public static ChunkEncoder optimalNonAllocatingInstance(int totalLength, BufferRecycler bufferRecycler) {
+        try {
+            return UnsafeChunkEncoders.createNonAllocatingEncoder(totalLength, bufferRecycler);
+        } catch (Exception e) {
+            return safeNonAllocatingInstance(totalLength, bufferRecycler);
+        }
+    }
+
+    /**
+     * Convenience method, equivalent to:
+     *<code>
+     *   return safeInstance(LZFChunk.MAX_CHUNK_LEN, bufferRecycler);
+     *</code>
+     */
+    public static ChunkEncoder safeInstance(BufferRecycler bufferRecycler) {
+        return safeInstance(LZFChunk.MAX_CHUNK_LEN, bufferRecycler);
+    }
+    /**
+     * Method that can be used to ensure that a "safe" compressor instance is loaded.
+     * Safe here means that it should work on any and all Java platforms.
+     *
+     * @param totalLength Expected total length of content to compress; only matters
+     *    for content that is smaller than maximum chunk size (64k), to optimize
+     *    encoding hash tables
+	 * @param bufferRecycler The BufferRecycler instance
+     */
+    public static ChunkEncoder safeInstance(int totalLength, BufferRecycler bufferRecycler) {
+        return new VanillaChunkEncoder(totalLength, bufferRecycler);
+    }
+
+    /**
+     * Factory method for constructing encoder that is always passed buffer
+     * externally, so that it will not (nor need) allocate encoding buffer.
+     */
+    public static ChunkEncoder safeNonAllocatingInstance(int totalLength, BufferRecycler bufferRecycler) {
+        return VanillaChunkEncoder.nonAllocatingEncoder(totalLength, bufferRecycler);
     }
 }

--- a/src/main/java/com/ning/compress/lzf/util/LZFFileInputStream.java
+++ b/src/main/java/com/ning/compress/lzf/util/LZFFileInputStream.java
@@ -77,47 +77,62 @@ public class LZFFileInputStream
      */
 
     public LZFFileInputStream(File file) throws FileNotFoundException {
-        this(file, ChunkDecoderFactory.optimalInstance());
+        this(file, ChunkDecoderFactory.optimalInstance(), BufferRecycler.instance());
     }
 
     public LZFFileInputStream(FileDescriptor fdObj) {
-        this(fdObj, ChunkDecoderFactory.optimalInstance());
+        this(fdObj, ChunkDecoderFactory.optimalInstance(), BufferRecycler.instance());
     }
 
     public LZFFileInputStream(String name) throws FileNotFoundException {
-        this(name, ChunkDecoderFactory.optimalInstance());
+        this(name, ChunkDecoderFactory.optimalInstance(), BufferRecycler.instance());
     }
     
     public LZFFileInputStream(File file, ChunkDecoder decompressor) throws FileNotFoundException
     {
-        super(file);
-        _decompressor = decompressor;
-        _recycler = BufferRecycler.instance();
-        _inputStreamClosed = false;
-        _inputBuffer = _recycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
-        _decodedBytes = _recycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
-        _wrapper = new Wrapper();
+        this(file, decompressor, BufferRecycler.instance());
     }
 
     public LZFFileInputStream(FileDescriptor fdObj, ChunkDecoder decompressor)
     {
-        super(fdObj);
-        _decompressor = decompressor;
-        _recycler = BufferRecycler.instance();
-        _inputStreamClosed = false;
-        _inputBuffer = _recycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
-        _decodedBytes = _recycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
-        _wrapper = new Wrapper();
+        this(fdObj, decompressor, BufferRecycler.instance());
     }
 
     public LZFFileInputStream(String name, ChunkDecoder decompressor) throws FileNotFoundException
     {
+        this(name, decompressor, BufferRecycler.instance());
+    }
+
+    public LZFFileInputStream(File file, ChunkDecoder decompressor, BufferRecycler bufferRecycler) throws FileNotFoundException
+    {
+        super(file);
+        _decompressor = decompressor;
+        _recycler = bufferRecycler;
+        _inputStreamClosed = false;
+        _inputBuffer = bufferRecycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _decodedBytes = bufferRecycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _wrapper = new Wrapper();
+    }
+
+    public LZFFileInputStream(FileDescriptor fdObj, ChunkDecoder decompressor, BufferRecycler bufferRecycler)
+    {
+        super(fdObj);
+        _decompressor = decompressor;
+        _recycler = bufferRecycler;
+        _inputStreamClosed = false;
+        _inputBuffer = bufferRecycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _decodedBytes = bufferRecycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _wrapper = new Wrapper();
+    }
+
+    public LZFFileInputStream(String name, ChunkDecoder decompressor, BufferRecycler bufferRecycler) throws FileNotFoundException
+    {
         super(name);
         _decompressor = decompressor;
-        _recycler = BufferRecycler.instance();
+        _recycler = bufferRecycler;
         _inputStreamClosed = false;
-        _inputBuffer = _recycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
-        _decodedBytes = _recycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _inputBuffer = bufferRecycler.allocInputBuffer(LZFChunk.MAX_CHUNK_LEN);
+        _decodedBytes = bufferRecycler.allocDecodeBuffer(LZFChunk.MAX_CHUNK_LEN);
         _wrapper = new Wrapper();
     }
 

--- a/src/main/java/com/ning/compress/lzf/util/LZFFileOutputStream.java
+++ b/src/main/java/com/ning/compress/lzf/util/LZFFileOutputStream.java
@@ -86,42 +86,65 @@ public class LZFFileOutputStream extends FileOutputStream implements WritableByt
     }
 
     public LZFFileOutputStream(ChunkEncoder encoder, File file) throws FileNotFoundException {
-        super(file);
-        _encoder = encoder;
-        _recycler = BufferRecycler.instance();
-        _outputBuffer = _recycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
-        _wrapper = new Wrapper();
+        this(encoder, file, encoder.getBufferRecycler());
     }
 
     public LZFFileOutputStream(ChunkEncoder encoder, File file, boolean append) throws FileNotFoundException {
-        super(file, append);
-        _encoder = encoder;
-        _recycler = BufferRecycler.instance();
-        _outputBuffer = _recycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
-        _wrapper = new Wrapper();
+        this(encoder, file, append, encoder.getBufferRecycler());
     }
 
     public LZFFileOutputStream(ChunkEncoder encoder, FileDescriptor fdObj) {
-        super(fdObj);
-        _encoder = encoder;
-        _recycler = BufferRecycler.instance();
-        _outputBuffer = _recycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
-        _wrapper = new Wrapper();
+        this(encoder, fdObj, encoder.getBufferRecycler());
     }
 
     public LZFFileOutputStream(ChunkEncoder encoder, String name) throws FileNotFoundException {
-        super(name);
-        _encoder = encoder;
-        _recycler = BufferRecycler.instance();
-        _outputBuffer = _recycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
-        _wrapper = new Wrapper();
+        this(encoder, name, encoder.getBufferRecycler());
     }
 
     public LZFFileOutputStream(ChunkEncoder encoder, String name, boolean append) throws FileNotFoundException {
+        this(encoder, name, append, encoder.getBufferRecycler());
+    }
+
+    public LZFFileOutputStream(ChunkEncoder encoder, File file, BufferRecycler bufferRecycler) throws FileNotFoundException {
+        super(file);
+        _encoder = encoder;
+		if (bufferRecycler==null) {
+			bufferRecycler = encoder.getBufferRecycler();
+		}
+        _recycler = bufferRecycler;
+        _outputBuffer = bufferRecycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
+        _wrapper = new Wrapper();
+    }
+
+    public LZFFileOutputStream(ChunkEncoder encoder, File file, boolean append, BufferRecycler bufferRecycler) throws FileNotFoundException {
+        super(file, append);
+        _encoder = encoder;
+        _recycler = bufferRecycler;
+        _outputBuffer = bufferRecycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
+        _wrapper = new Wrapper();
+    }
+
+    public LZFFileOutputStream(ChunkEncoder encoder, FileDescriptor fdObj, BufferRecycler bufferRecycler) {
+        super(fdObj);
+        _encoder = encoder;
+        _recycler = bufferRecycler;
+        _outputBuffer = bufferRecycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
+        _wrapper = new Wrapper();
+    }
+
+    public LZFFileOutputStream(ChunkEncoder encoder, String name, BufferRecycler bufferRecycler) throws FileNotFoundException {
+        super(name);
+        _encoder = encoder;
+        _recycler = bufferRecycler;
+        _outputBuffer = bufferRecycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
+        _wrapper = new Wrapper();
+    }
+
+    public LZFFileOutputStream(ChunkEncoder encoder, String name, boolean append, BufferRecycler bufferRecycler) throws FileNotFoundException {
         super(name, append);
         _encoder = encoder;
-        _recycler = BufferRecycler.instance();
-        _outputBuffer = _recycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
+        _recycler = bufferRecycler;
+        _outputBuffer = bufferRecycler.allocOutputBuffer(OUTPUT_BUFFER_SIZE);
         _wrapper = new Wrapper();
     }
 


### PR DESCRIPTION
... allow specifying a concrete BufferRecycler instance, as an alternative to the default ThreadLocal soft-references policy.

The change does not break compatibility with existing API, but adds flexibility for resource-eficiency if used from pools (different threads could reuse the same BufferRecycler instances, avoiding the creation of instances on a per Thread basis) and some minor performance gain in preexistent LZFOutputStream constructors (because ThreadLocal is only accessed once).
