### PR TITLE
Treat sun.misc as an optional dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,9 +117,10 @@ See "http://oldhome.schmorp.de/marc/liblzf.html" for more on original LZF packag
           <configuration>
             <instructions><!--  note: artifact id, name, version and description use defaults (which are fine) -->
               <Bundle-Vendor>http://ning.com</Bundle-Vendor>
-              <Import-Package />
-              <!-- if using high-perf decoder: -->
-              <DynamicImport-Package>sun.misc</DynamicImport-Package>
+<!-- if using high-perf decoder: -->
+              <Import-Package>
+sun.misc;resolution:=optional, *
+              <Import-Package/>
               <Private-Package>
 com.ning.compress.lzf.impl
               </Private-Package>


### PR DESCRIPTION
We currently get this nag screen

![image](https://user-images.githubusercontent.com/756669/214811451-a87b4b72-9f36-43e7-99dd-a0ff3c00f24c.png)

when importing via @eclipse-m2e. 

According to https://bnd.bndtools.org/chapters/920-faq.html#remove-unwanted-imports- this should make it a proper optional dependency