### PR TITLE
Validate arguments for `Unsafe` codecs

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,6 +1,6 @@
 1.2.0 (not yet released)
 
-#54: Validate arguments for `Unsafe` coders
+#54: Validate arguments for `Unsafe` codecs
  (contributed by @Marcono1234)
 #60: Convert tests to JUnit 5 & refactor tests
  (contributed by @Marcono1234)

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,5 +1,7 @@
 1.2.0 (not yet released)
 
+#54: Validate arguments for `Unsafe` coders
+ (contributed by @Marcono1234)
 #60: Convert tests to JUnit 5 & refactor tests
  (contributed by @Marcono1234)
 #61: Prevent user code from subclassing `UnsafeChunkEncoder`

--- a/src/main/java/com/ning/compress/lzf/ChunkEncoder.java
+++ b/src/main/java/com/ning/compress/lzf/ChunkEncoder.java
@@ -93,8 +93,11 @@ public abstract class ChunkEncoder
      */
     protected ChunkEncoder(int totalLength, BufferRecycler bufferRecycler)
     {
+        if (totalLength <= 0) {
+            throw new IllegalArgumentException("Invalid total length: " + totalLength);
+        }
         // Need room for at most a single full chunk
-        int largestChunkLen = Math.min(totalLength, LZFChunk.MAX_CHUNK_LEN);       
+        int largestChunkLen = Math.min(totalLength, LZFChunk.MAX_CHUNK_LEN);
         int suggestedHashLen = calcHashLen(largestChunkLen);
         _recycler = bufferRecycler;
         _hashTable = bufferRecycler.allocEncodingHash(suggestedHashLen);

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkDecoder.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkDecoder.java
@@ -71,6 +71,10 @@ public class UnsafeChunkDecoder extends ChunkDecoder
     public final void decodeChunk(byte[] in, int inPos, byte[] out, int outPos, int outEnd)
         throws LZFException
     {
+        // Sanity checks; otherwise if any of the arguments are invalid `Unsafe` might corrupt memory
+        checkArrayIndices(in, inPos, in.length);
+        checkArrayIndices(out, outPos, outEnd);
+
         // We need to take care of end condition, leave last 32 bytes out
         final int outputEnd8 = outEnd - 8;
         final int outputEnd32 = outEnd - 32;
@@ -175,7 +179,17 @@ public class UnsafeChunkDecoder extends ChunkDecoder
     // Internal methods
     ///////////////////////////////////////////////////////////////////////
      */
-    
+
+    /**
+     * @param start start index, inclusive
+     * @param end end index, exclusive
+     */
+    private static void checkArrayIndices(byte[] array, int start, int end) {
+        if (start < 0 || end < start || end > array.length) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+    }
+
     private final int copyOverlappingShort(final byte[] out, int outPos, final int offset, int len)
     {
         out[outPos] = out[outPos++ + offset];

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoder.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoder.java
@@ -72,6 +72,14 @@ public abstract class UnsafeChunkEncoder
         }
     }
 
+    static void _checkOutputLength(int inputLen, int outputLen) {
+        int maxEncoded = inputLen + ((inputLen + 31) >> 5);
+
+        if (maxEncoded > outputLen) {
+            throw new IllegalArgumentException("Output length " + outputLen + " is too small for input length " + inputLen);
+        }
+    }
+
     final static int _copyPartialLiterals(byte[] in, int inPos, byte[] out, int outPos,
             int literals)
     {

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoder.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoder.java
@@ -62,6 +62,16 @@ public abstract class UnsafeChunkEncoder
     ///////////////////////////////////////////////////////////////////////
      */
 
+    /**
+     * @param start start index, inclusive
+     * @param end end index, exclusive
+     */
+    static void _checkArrayIndices(byte[] array, int start, int end) {
+        if (start < 0 || end < start || end > array.length) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+    }
+
     final static int _copyPartialLiterals(byte[] in, int inPos, byte[] out, int outPos,
             int literals)
     {

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderBE.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderBE.java
@@ -32,7 +32,7 @@ public final class UnsafeChunkEncoderBE
         // Sanity checks; otherwise if any of the arguments are invalid `Unsafe` might corrupt memory
         _checkArrayIndices(in, inPos, inEnd);
         _checkArrayIndices(out, outPos, out.length);
-        // TODO: Validate that `out.length - outPos` is large enough?
+        _checkOutputLength(inEnd - inPos, out.length - outPos);
 
         final int[] hashTable = _hashTable;
         int literals = 0;

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderBE.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderBE.java
@@ -29,6 +29,11 @@ public final class UnsafeChunkEncoderBE
     @Override
     protected int tryCompress(byte[] in, int inPos, int inEnd, byte[] out, int outPos)
     {
+        // Sanity checks; otherwise if any of the arguments are invalid `Unsafe` might corrupt memory
+        _checkArrayIndices(in, inPos, inEnd);
+        _checkArrayIndices(out, outPos, out.length);
+        // TODO: Validate that `out.length - outPos` is large enough?
+
         final int[] hashTable = _hashTable;
         int literals = 0;
         inEnd -= TAIL_LENGTH;
@@ -83,7 +88,7 @@ public final class UnsafeChunkEncoderBE
             ++inPos;
         }
         // try offlining the tail
-        return _handleTail(in, inPos, inEnd+4, out, outPos, literals);
+        return _handleTail(in, inPos, inEnd+TAIL_LENGTH, out, outPos, literals);
     }
 
     private final static int _getInt(final byte[] in, final int inPos) {

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderLE.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderLE.java
@@ -32,7 +32,7 @@ public final class UnsafeChunkEncoderLE
         // Sanity checks; otherwise if any of the arguments are invalid `Unsafe` might corrupt memory
         _checkArrayIndices(in, inPos, inEnd);
         _checkArrayIndices(out, outPos, out.length);
-        // TODO: Validate that `out.length - outPos` is large enough?
+        _checkOutputLength(inEnd - inPos, out.length - outPos);
 
         final int[] hashTable = _hashTable;
         int literals = 0;

--- a/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderLE.java
+++ b/src/main/java/com/ning/compress/lzf/impl/UnsafeChunkEncoderLE.java
@@ -29,6 +29,11 @@ public final class UnsafeChunkEncoderLE
 	@Override
     protected int tryCompress(byte[] in, int inPos, int inEnd, byte[] out, int outPos)
     {
+        // Sanity checks; otherwise if any of the arguments are invalid `Unsafe` might corrupt memory
+        _checkArrayIndices(in, inPos, inEnd);
+        _checkArrayIndices(out, outPos, out.length);
+        // TODO: Validate that `out.length - outPos` is large enough?
+
         final int[] hashTable = _hashTable;
         int literals = 0;
         inEnd -= TAIL_LENGTH;
@@ -85,7 +90,7 @@ public final class UnsafeChunkEncoderLE
             ++inPos;
         }
         // try offlining the tail
-        return _handleTail(in, inPos, inEnd+4, out, outPos, literals);
+        return _handleTail(in, inPos, inEnd+TAIL_LENGTH, out, outPos, literals);
     }
 
     private final static int _getInt(final byte[] in, final int inPos) {

--- a/src/test/java/com/ning/compress/lzf/LZFEncoderTest.java
+++ b/src/test/java/com/ning/compress/lzf/LZFEncoderTest.java
@@ -4,6 +4,9 @@ import java.io.*;
 import java.util.Arrays;
 
 import com.ning.compress.BaseForTests;
+import com.ning.compress.lzf.impl.UnsafeChunkEncoder;
+import com.ning.compress.lzf.impl.UnsafeChunkEncoderBE;
+import com.ning.compress.lzf.impl.UnsafeChunkEncoderLE;
 import com.ning.compress.lzf.util.ChunkEncoderFactory;
 import org.junit.jupiter.api.Test;
 
@@ -162,5 +165,27 @@ public class LZFEncoderTest extends BaseForTests
 
         chunk = enc.encodeChunkIfCompresses(input, 0, input.length, 0.60);
         assertNull(chunk);
+    }
+
+    @Test
+    public void testUnsafeValidation() {
+        _testUnsafeValidation(new UnsafeChunkEncoderBE(10));
+        _testUnsafeValidation(new UnsafeChunkEncoderLE(10));
+
+    }
+
+    private void _testUnsafeValidation(UnsafeChunkEncoder encoder) {
+        byte[] array = new byte[10];
+        int goodStart = 2;
+        int goodEnd = 5;
+
+        assertThrows(NullPointerException.class, () -> encoder.tryCompress(null, goodStart, goodEnd, array, goodStart));
+        assertThrows(NullPointerException.class, () -> encoder.tryCompress(array, goodStart, goodEnd, null, goodStart));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> encoder.tryCompress(array, -1, goodEnd, array, goodStart));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> encoder.tryCompress(array, 12, goodEnd, array, goodStart));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> encoder.tryCompress(array, goodStart, 1, array, goodStart));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> encoder.tryCompress(array, goodStart, 12, array, goodStart));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> encoder.tryCompress(array, goodStart, goodEnd, array, -1));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> encoder.tryCompress(array, goodStart, goodEnd, array, 12));
     }
 }

--- a/src/test/java/com/ning/compress/lzf/TestLZFDecoder.java
+++ b/src/test/java/com/ning/compress/lzf/TestLZFDecoder.java
@@ -4,10 +4,12 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 import com.ning.compress.BaseForTests;
+import com.ning.compress.lzf.impl.UnsafeChunkDecoder;
 import com.ning.compress.lzf.util.ChunkDecoderFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestLZFDecoder extends BaseForTests
 {
@@ -27,6 +29,22 @@ public class TestLZFDecoder extends BaseForTests
     public void testChunks() throws IOException {
         _testChunks(ChunkDecoderFactory.safeInstance());
         _testChunks(ChunkDecoderFactory.optimalInstance());
+    }
+
+    @Test
+    public void testUnsafeValidation() {
+        UnsafeChunkDecoder decoder = new UnsafeChunkDecoder();
+
+        byte[] array = new byte[10];
+        int goodStart = 2;
+        int goodEnd = 5;
+        assertThrows(NullPointerException.class, () -> decoder.decodeChunk(null, goodStart, array, goodStart, goodEnd));
+        assertThrows(NullPointerException.class, () -> decoder.decodeChunk(array, goodStart, null, goodStart, goodEnd));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> decoder.decodeChunk(array, -1, array, goodStart, goodEnd));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> decoder.decodeChunk(array, 12, array, goodStart, goodEnd));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> decoder.decodeChunk(array, goodStart, array, -1, goodEnd));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> decoder.decodeChunk(array, goodStart, array, goodStart, 1));
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> decoder.decodeChunk(array, goodStart, array, goodStart, 12));
     }
 
     /*


### PR DESCRIPTION
Adds validation for the encoder and decoder using `Unsafe` to protect against accidental memory corruption. This is mainly to protect against implementation bugs, and against users who might by accident provide invalid arguments.

I am not very familiar with this code, so any feedback and corrections are welcome!
I have added some review comments below to explain the rationale for the changes.

Assuming users are not using any of these low level methods or classes directly, this probably has no security impact.