### PR TITLE
Use try-with-resources for TestFileStreams

### DIFF
--- a/src/test/java/com/ning/compress/lzf/TestLZFInputStream.java
+++ b/src/test/java/com/ning/compress/lzf/TestLZFInputStream.java
@@ -31,7 +31,7 @@ public class TestLZFInputStream extends BaseForTests
 			System.arraycopy(bytes, 0, bytesToWrite, cursor, (bytes.length+cursor < bytesToWrite.length)?bytes.length:bytesToWrite.length-cursor);
 			cursor += bytes.length;
 		}
-	        ByteArrayOutputStream nonCompressed = new ByteArrayOutputStream();
+        ByteArrayOutputStream nonCompressed = new ByteArrayOutputStream();
 		OutputStream os = new LZFOutputStream(nonCompressed);
 		os.write(nonEncodableBytesToWrite);
 		os.close();
@@ -88,7 +88,7 @@ public class TestLZFInputStream extends BaseForTests
         assertSame(bis, is.getUnderlyingInputStream());
         assertEquals(0, is.available());
         // read one byte; should decode bunch more, make available
-        is.read();
+        assertNotEquals(-1, is.read());
         int total = 1; // since we read one byte already
         assertEquals(65534, is.available());
         // and after we skip through all of it, end with -1 for EOF

--- a/src/test/java/com/ning/compress/lzf/util/TestFileStreams.java
+++ b/src/test/java/com/ning/compress/lzf/util/TestFileStreams.java
@@ -24,20 +24,20 @@ public class TestFileStreams extends BaseForTests
         // First, write encoded stuff (won't compress, but produces something)
         byte[] input = "Whatever stuff...".getBytes(StandardCharsets.UTF_8);
 
-        LZFFileOutputStream out = new LZFFileOutputStream(f);
-        out.write(input);
-        out.close();
+        try (LZFFileOutputStream out = new LZFFileOutputStream(f)) {
+            out.write(input);
+        }
 
         long len = f.length();
         // happens to be 22; 17 bytes uncompressed, with 5 byte header
         assertEquals(22L, len);
 
-        LZFFileInputStream in = new LZFFileInputStream(f);
-        for (byte b : input) {
-            assertEquals(b & 0xFF, in.read());
+        try (LZFFileInputStream in = new LZFFileInputStream(f)) {
+            for (byte b : input) {
+                assertEquals(b & 0xFF, in.read());
+            }
+            assertEquals(-1, in.read());
         }
-        assertEquals(-1, in.read());
-        in.close();
     }
 
     @Test 
@@ -46,14 +46,14 @@ public class TestFileStreams extends BaseForTests
         File f = tempDir.resolve("lzf-test.lzf").toFile();
 
         byte[] fluff = constructFluff(132000);
-        LZFFileOutputStream fout = new LZFFileOutputStream(f);
-        fout.write(fluff);
-        fout.close();
-        
-        LZFFileInputStream in = new LZFFileInputStream(f);
+        try (LZFFileOutputStream fout = new LZFFileOutputStream(f)) {
+            fout.write(fluff);
+        }
+
         ByteArrayOutputStream bytes = new ByteArrayOutputStream(fluff.length);
-        in.readAndWrite(bytes);
-        in.close();
+        try (LZFFileInputStream in = new LZFFileInputStream(f)) {
+            in.readAndWrite(bytes);
+        }
         byte[] actual = bytes.toByteArray();
         assertArrayEquals(fluff, actual);
     }


### PR DESCRIPTION
Otherwise when an exception occurs, the file streams remain open and JUnit is unable to delete the temp dir.